### PR TITLE
feat: distroless iamge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN --mount=type=cache,uid=1000,gid=1000,target=/home/op/.cache/pip pip install 
 
 # use distroless/cc as the base for our final image
 # lots of python depends on glibc
-FROM gcr.io/distroless/cc-debian11:debug
+FROM gcr.io/distroless/cc-debian11
 
 # Copy python from the python-builder
 # this carries more risk than installing it fully, but makes the image a lot smaller

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-buster as builder
+FROM python:3.10-slim-bullseye as wheel-builder
 
 ADD src /src
 ADD poetry.lock /poetry.lock
@@ -6,15 +6,90 @@ ADD pyproject.toml /pyproject.toml
 ADD README.md /README.md
 ADD constraints.txt /constraints.txt
 
+# build the wheel
 RUN --mount=type=cache,target=/root/.cache/pip pip install --upgrade pip twine build --constraint /constraints.txt
 RUN --mount=type=cache,target=/root/.cache/pip python -m build --sdist --wheel --outdir /dist/
 RUN twine check /dist/*
 
-FROM python:3.10-slim-buster
+FROM python:3.10-slim-bullseye as python-base
 
-COPY --from=builder /dist /dist
-RUN --mount=type=cache,target=/root/.cache/pip pip install /dist/*.whl
-RUN adduser --no-create-home nonroot
+# Update the base image
+RUN apt-get update && apt-get upgrade -y
 
-USER nonroot
+# Setup a non-root user
+ARG NONROOT_USER="op"
+ARG NONROOT_GROUP="op"
+
+RUN groupadd ${NONROOT_GROUP}
+RUN useradd -m ${NONROOT_USER} -g ${NONROOT_GROUP}
+
+USER ${NONROOT_USER}
+ENV PATH="/home/${NONROOT_USER}/.local/bin:${PATH}"
+WORKDIR /home/${NONROOT_USER}
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONFAULTHANDLER 1
+
+# upgrade pip and virtualenv
+COPY --from=wheel-builder /constraints.txt /constraints.txt
+RUN --mount=type=cache,uid=1000,gid=1000,target=/home/op/.cache/pip pip install --upgrade pip --constraint /constraints.txt && \
+    pip install --no-warn-script-location --upgrade virtualenv --constraint /constraints.txt
+
+# Copy the whl from the wheel-builder stage
+COPY --from=wheel-builder /dist/*.whl /dist/
+
+# Pip install the wheel into a target dir
+RUN --mount=type=cache,uid=1000,gid=1000,target=/home/op/.cache/pip pip install --no-warn-script-location --target ./app /dist/*.whl
+
+# use distroless/cc as the base for our final image
+# lots of python depends on glibc
+FROM gcr.io/distroless/cc-debian11:debug
+
+# Copy python from the python-builder
+# this carries more risk than installing it fully, but makes the image a lot smaller
+COPY --from=python-base /usr/local/lib/ /usr/local/lib/
+COPY --from=python-base /usr/local/bin/python /usr/local/bin/python
+COPY --from=python-base /etc/ld.so.cache /etc/ld.so.cache
+
+# Add some common compiled libraries
+# If seeing ImportErrors, check if in the python-base already and copy as below
+# required by lots of packages - e.g. six, numpy, wsgi
+# *-linux-gnu makes this builder work with either linux/arm64 or linux/amd64
+COPY --from=python-base /lib/*-linux-gnu/libz.so.1 /lib/libs/
+COPY --from=python-base /usr/lib/*-linux-gnu/libffi* /lib/libs/
+COPY --from=python-base /lib/*-linux-gnu/libexpat* /lib/libs/
+
+# Add some system utils
+COPY --from=python-base /bin/echo /bin/echo
+COPY --from=python-base /bin/rm /bin/rm
+COPY --from=python-base /bin/sh /bin/sh
+
+# Copy over the app
+COPY --from=python-base /home/op/app /app
+
+# non root user stuff
+RUN echo "op:x:1000:op" >> /etc/group
+RUN echo "op:x:1001:" >> /etc/group
+RUN echo "op:x:1000:1001::/home/op:" >> /etc/passwd
+
+# Remove shell utils and pip
+RUN rm /bin/sh /bin/echo /bin/rm
+
+# default to running as non-root, uid=1000
+USER op
+
+# Add /lib/libs to our path
+ENV LD_LIBRARY_PATH="/lib/libs:${LD_LIBRARY_PATH}"
+# Add the app path to our path
+ENV PATH="/app/bin:${PATH}"
+# Add the app path to your python path
+ENV PYTHONPATH="/app:${PYTHONPATH}"
+# standardise on locale, don't generate .pyc, enable tracebacks on seg faults
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONFAULTHANDLER 1
+
+
 ENTRYPOINT ["r53operator"]

--- a/poetry.lock
+++ b/poetry.lock
@@ -1460,19 +1460,6 @@ secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "p
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
-name = "uvloop"
-version = "0.17.0"
-description = "Fast implementation of asyncio event loop on top of libuv"
-category = "main"
-optional = false
-python-versions = ">=3.7"
-
-[package.extras]
-dev = ["Cython (>=0.29.32,<0.30.0)", "Sphinx (>=4.1.2,<4.2.0)", "aiohttp", "flake8 (>=3.9.2,<3.10.0)", "mypy (>=0.800)", "psutil", "pyOpenSSL (>=22.0.0,<22.1.0)", "pycodestyle (>=2.7.0,<2.8.0)", "pytest (>=3.6.0)", "sphinx-rtd-theme (>=0.5.2,<0.6.0)", "sphinxcontrib-asyncio (>=0.3.0,<0.4.0)"]
-docs = ["Sphinx (>=4.1.2,<4.2.0)", "sphinx-rtd-theme (>=0.5.2,<0.6.0)", "sphinxcontrib-asyncio (>=0.3.0,<0.4.0)"]
-test = ["Cython (>=0.29.32,<0.30.0)", "aiohttp", "flake8 (>=3.9.2,<3.10.0)", "mypy (>=0.800)", "psutil", "pyOpenSSL (>=22.0.0,<22.1.0)", "pycodestyle (>=2.7.0,<2.8.0)"]
-
-[[package]]
 name = "virtualenv"
 version = "20.16.7"
 description = "Virtual Python Environment builder"
@@ -1544,7 +1531,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "5d7d8c471b26caa10278046b616ab54c9b166e55d6c68be338ea78181616066d"
+content-hash = "97b42eda036e69e8a763bdc4e5d0bf567c92a3ae2379b0fe52bae8c7737848b0"
 
 [metadata.files]
 aiobotocore = [
@@ -2541,38 +2528,6 @@ typing-extensions = [
 urllib3 = [
     {file = "urllib3-1.26.12-py2.py3-none-any.whl", hash = "sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997"},
     {file = "urllib3-1.26.12.tar.gz", hash = "sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e"},
-]
-uvloop = [
-    {file = "uvloop-0.17.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ce9f61938d7155f79d3cb2ffa663147d4a76d16e08f65e2c66b77bd41b356718"},
-    {file = "uvloop-0.17.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:68532f4349fd3900b839f588972b3392ee56042e440dd5873dfbbcd2cc67617c"},
-    {file = "uvloop-0.17.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0949caf774b9fcefc7c5756bacbbbd3fc4c05a6b7eebc7c7ad6f825b23998d6d"},
-    {file = "uvloop-0.17.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ff3d00b70ce95adce264462c930fbaecb29718ba6563db354608f37e49e09024"},
-    {file = "uvloop-0.17.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:a5abddb3558d3f0a78949c750644a67be31e47936042d4f6c888dd6f3c95f4aa"},
-    {file = "uvloop-0.17.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8efcadc5a0003d3a6e887ccc1fb44dec25594f117a94e3127954c05cf144d811"},
-    {file = "uvloop-0.17.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:3378eb62c63bf336ae2070599e49089005771cc651c8769aaad72d1bd9385a7c"},
-    {file = "uvloop-0.17.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6aafa5a78b9e62493539456f8b646f85abc7093dd997f4976bb105537cf2635e"},
-    {file = "uvloop-0.17.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c686a47d57ca910a2572fddfe9912819880b8765e2f01dc0dd12a9bf8573e539"},
-    {file = "uvloop-0.17.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:864e1197139d651a76c81757db5eb199db8866e13acb0dfe96e6fc5d1cf45fc4"},
-    {file = "uvloop-0.17.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:2a6149e1defac0faf505406259561bc14b034cdf1d4711a3ddcdfbaa8d825a05"},
-    {file = "uvloop-0.17.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:6708f30db9117f115eadc4f125c2a10c1a50d711461699a0cbfaa45b9a78e376"},
-    {file = "uvloop-0.17.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:23609ca361a7fc587031429fa25ad2ed7242941adec948f9d10c045bfecab06b"},
-    {file = "uvloop-0.17.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2deae0b0fb00a6af41fe60a675cec079615b01d68beb4cc7b722424406b126a8"},
-    {file = "uvloop-0.17.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:45cea33b208971e87a31c17622e4b440cac231766ec11e5d22c76fab3bf9df62"},
-    {file = "uvloop-0.17.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:9b09e0f0ac29eee0451d71798878eae5a4e6a91aa275e114037b27f7db72702d"},
-    {file = "uvloop-0.17.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:dbbaf9da2ee98ee2531e0c780455f2841e4675ff580ecf93fe5c48fe733b5667"},
-    {file = "uvloop-0.17.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:a4aee22ece20958888eedbad20e4dbb03c37533e010fb824161b4f05e641f738"},
-    {file = "uvloop-0.17.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:307958f9fc5c8bb01fad752d1345168c0abc5d62c1b72a4a8c6c06f042b45b20"},
-    {file = "uvloop-0.17.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3ebeeec6a6641d0adb2ea71dcfb76017602ee2bfd8213e3fcc18d8f699c5104f"},
-    {file = "uvloop-0.17.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1436c8673c1563422213ac6907789ecb2b070f5939b9cbff9ef7113f2b531595"},
-    {file = "uvloop-0.17.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:8887d675a64cfc59f4ecd34382e5b4f0ef4ae1da37ed665adba0c2badf0d6578"},
-    {file = "uvloop-0.17.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:3db8de10ed684995a7f34a001f15b374c230f7655ae840964d51496e2f8a8474"},
-    {file = "uvloop-0.17.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:7d37dccc7ae63e61f7b96ee2e19c40f153ba6ce730d8ba4d3b4e9738c1dccc1b"},
-    {file = "uvloop-0.17.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:cbbe908fda687e39afd6ea2a2f14c2c3e43f2ca88e3a11964b297822358d0e6c"},
-    {file = "uvloop-0.17.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3d97672dc709fa4447ab83276f344a165075fd9f366a97b712bdd3fee05efae8"},
-    {file = "uvloop-0.17.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f1e507c9ee39c61bfddd79714e4f85900656db1aec4d40c6de55648e85c2799c"},
-    {file = "uvloop-0.17.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:c092a2c1e736086d59ac8e41f9c98f26bbf9b9222a76f21af9dfe949b99b2eb9"},
-    {file = "uvloop-0.17.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:30babd84706115626ea78ea5dbc7dd8d0d01a2e9f9b306d24ca4ed5796c66ded"},
-    {file = "uvloop-0.17.0.tar.gz", hash = "sha256:0ddf6baf9cf11a1a22c71487f39f15b2cf78eb5bde7e5b45fbb99e8a9d91b9e1"},
 ]
 virtualenv = [
     {file = "virtualenv-20.16.7-py3-none-any.whl", hash = "sha256:efd66b00386fdb7dbe4822d172303f40cd05e50e01740b19ea42425cbe653e29"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ Changelog = "https://github.com/andrewthetechie/route53-operator/releases"
 [tool.poetry.dependencies]
 python = "^3.10"
 kopf = "^1.36.0"
-uvloop = "^0.17.0"
 aiobotocore = "^2.4.0"
 pykube-ng = "^22.9.0"
 pydantic = "^1.10.2"

--- a/src/route53_operator/__main__.py
+++ b/src/route53_operator/__main__.py
@@ -1,8 +1,5 @@
 """This is our poetry entrypoint, run with r53operator. It loads the kopf handlers and registry and starts the kopf operator"""
-import asyncio
 import logging
-
-import uvloop
 
 from . import handlers  # noqa: F401
 from . import kopf
@@ -10,8 +7,6 @@ from . import kopf_registry
 
 
 def cli(args=None):
-    # TODO: Figure out how we can pass sysargv or env vars in to configure kopf
-    asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
     settings = kopf.OperatorSettings()
     settings.posting.level = logging.DEBUG
     kopf.run(registry=kopf_registry, namespace="default", settings=settings)

--- a/src/route53_operator/handlers/v1/a.py
+++ b/src/route53_operator/handlers/v1/a.py
@@ -1,6 +1,6 @@
 """Handlers for A Records"""
+from logging import Logger
 from typing import Any
-from typing import Logger
 
 from ... import kopf
 from ... import kopf_registry


### PR DESCRIPTION
This PR moves to a distroless image with python3.10 and a minimum footprint.

The old image was 223MB in size, this one is 142MB

It also removes uvloop, which was just an extra dependency and wasn't really in use. It also fixes a bug with a misplaced import

Implements https://github.com/andrewthetechie/route53-operator/issues/14